### PR TITLE
Removed the functionality for setting log levels;

### DIFF
--- a/PostSharpTutorial/LoggerAspect.Tests/LoggerAspect.Tests.csproj
+++ b/PostSharpTutorial/LoggerAspect.Tests/LoggerAspect.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="LoggingAspectBaseFunctionalityTests.cs" />
     <Compile Include="MockLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestClasses.cs" />
     <Compile Include="TestExcludeProperties.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/PostSharpTutorial/LoggerAspect.Tests/LoggingAspectBaseFunctionalityTests.cs
+++ b/PostSharpTutorial/LoggerAspect.Tests/LoggingAspectBaseFunctionalityTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions;
+using LoggerAspect.Enums;
 using NUnit.Framework;
 
 namespace LoggerAspect.Tests
@@ -7,25 +8,29 @@ namespace LoggerAspect.Tests
     [TestFixture]
     public class LoggingAspectBaseFunctionalityTests
     {
+        private MockLogger _logger;
+
+        [SetUp]
+        public void InitializeTest()
+        {
+            _logger = new MockLogger();
+            LoggingAspect.Logger = _logger;
+        }
+
         [Test]
         public void WhenCallingWorkingMethod_ShouldHitDebug3Times()
         {
-            // arrange
-            var logger = new MockLogger();
-            LoggingAspect.Logger = logger;
             // act
             SomeMethod();
 
             // assert
-            logger.DebugCallCount.Should().Be(3, "because we only hit the Entry, Succes, and Exit methods");
+            _logger.DebugCallCount.Should().Be(3, "because we only hit the Entry, Succes, and Exit methods");
         }
 
         [Test]
         public void WhenCallingMethodWithException_ShouldHitDebugAndError()
         {
-            // arrange
-            var logger = new MockLogger();
-            LoggingAspect.Logger = logger;
+
 
             // act
             try
@@ -35,9 +40,9 @@ namespace LoggerAspect.Tests
             catch (Exception e) // we leave the base exception type here so we can catch any exception and later verify that it is the right type
             {
                 // assert
-                e.Should().BeOfType<NotImplementedException>("because we only explictly threw a NotImplementedException");
-                logger.DebugCallCount.Should().Be(2, "becase we should only hit the Entry and Exit methods");
-                logger.ErrorCallCount.Should().Be(1, "because we should hit the Exception method");
+                e.Should().BeOfType<NotImplementedException>("because we only explicitly threw a NotImplementedException");
+                _logger.DebugCallCount.Should().Be(2, "becase we should only hit the Entry and Exit methods");
+                _logger.ErrorCallCount.Should().Be(1, "because we should hit the Exception method");
             }
         }
 

--- a/PostSharpTutorial/LoggerAspect.Tests/TestClasses.cs
+++ b/PostSharpTutorial/LoggerAspect.Tests/TestClasses.cs
@@ -1,0 +1,120 @@
+﻿using LoggerAspect.Enums;
+
+namespace LoggerAspect.Tests
+{
+
+    [LoggingAspect]
+    public class Person
+    {
+        public string Name { get; set; }
+    }
+
+    [LoggingAspect(Exclude = ExclusionFlags.Properties)]
+    public class PersonExcludeProperty
+    {
+        public string Name { get; set; }
+    }
+
+    [LoggingAspect(Exclude = ExclusionFlags.InstanceConstructors)]
+    public class PersonExcludeInstanceConstructor
+    {
+        public PersonExcludeInstanceConstructor()
+        {
+        }
+
+        public string Name { get; set; }
+    }
+
+    [LoggingAspect(Exclude = ExclusionFlags.StaticConstructor)]
+    public class PersonExcludeStaticConstructor
+    {
+        static PersonExcludeStaticConstructor()
+        {
+
+        }
+
+
+        public string Name { get; set; }
+    }
+
+    [LoggingAspect(Exclude = ExclusionFlags.PropertySetters)]
+    public class PersonExcludePropertySetters
+    {
+        static PersonExcludePropertySetters()
+        {
+
+        }
+
+        public PersonExcludePropertySetters()
+        {
+        }
+
+        public PersonExcludePropertySetters(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; set; }
+    }
+
+    [LoggingAspect(Exclude = ExclusionFlags.PropertyGetters)]
+    public class PersonExcludePropertyGetters
+    {
+        static PersonExcludePropertyGetters()
+        {
+
+        }
+
+        public PersonExcludePropertyGetters()
+        {
+        }
+
+        public PersonExcludePropertyGetters(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; set; }
+    }
+
+    [LoggingAspect(Exclude = ExclusionFlags.Constructors)]
+    public class PersonExcludeConstructors
+    {
+        static PersonExcludeConstructors()
+        {
+
+        }
+
+        public PersonExcludeConstructors()
+        {
+        }
+
+        public PersonExcludeConstructors(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; set; }
+    }
+
+    [LoggingAspect(Exclude = ExclusionFlags.Properties | ExclusionFlags.Constructors)]
+    public class PersonExcludePropertyConstructors
+    {
+        static PersonExcludePropertyConstructors()
+        {
+
+        }
+
+        public PersonExcludePropertyConstructors()
+        {
+        }
+
+        public PersonExcludePropertyConstructors(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; set; }
+    }
+
+}

--- a/PostSharpTutorial/LoggerAspect.Tests/TestExcludeProperties.cs
+++ b/PostSharpTutorial/LoggerAspect.Tests/TestExcludeProperties.cs
@@ -18,8 +18,9 @@ namespace LoggerAspect.Tests
         }
 
         [Test]
-        public void WhenAppliedToClassWithNoExclude_ShouldLogProperty()
+        public void WhenAppliedToClassWithNoExclude_ShouldLogPropertyAndConstructor()
         {
+
             // act
             var p = new Person {Name = Guid.NewGuid().ToString()};
 
@@ -112,119 +113,5 @@ namespace LoggerAspect.Tests
                 .Be(0, "because we do not hit the Debug method for constructors and properties");
         }
 
-    }
-
-    [LoggingAspect]
-    public class Person
-    {
-        public string Name { get; set; }
-    }
-
-    [LoggingAspect(Exclude = ExclusionFlags.Properties)]
-    public class PersonExcludeProperty
-    {
-        public string Name { get; set; }
-    }
-
-    [LoggingAspect(Exclude = ExclusionFlags.InstanceConstructors)]
-    public class PersonExcludeInstanceConstructor
-    {
-        public PersonExcludeInstanceConstructor()
-        {
-        }
-
-        public string Name { get; set; }
-    }
-
-    [LoggingAspect(Exclude = ExclusionFlags.StaticConstructor)]
-    public class PersonExcludeStaticConstructor
-    {
-        static PersonExcludeStaticConstructor()
-        {
-
-        }
-
-
-        public string Name { get; set; }
-    }
-
-    [LoggingAspect(Exclude = ExclusionFlags.PropertySetters)]
-    public class PersonExcludePropertySetters
-    {
-        static PersonExcludePropertySetters()
-        {
-
-        }
-
-        public PersonExcludePropertySetters()
-        {
-        }
-
-        public PersonExcludePropertySetters(string name)
-        {
-            Name = name;
-        }
-
-        public string Name { get; set; }
-    }
-
-    [LoggingAspect(Exclude = ExclusionFlags.PropertyGetters)]
-    public class PersonExcludePropertyGetters
-    {
-        static PersonExcludePropertyGetters()
-        {
-
-        }
-
-        public PersonExcludePropertyGetters()
-        {
-        }
-
-        public PersonExcludePropertyGetters(string name)
-        {
-            Name = name;
-        }
-
-        public string Name { get; set; }
-    }
-
-    [LoggingAspect(Exclude = ExclusionFlags.Constructors)]
-    public class PersonExcludeConstructors
-    {
-        static PersonExcludeConstructors()
-        {
-
-        }
-
-        public PersonExcludeConstructors()
-        {
-        }
-
-        public PersonExcludeConstructors(string name)
-        {
-            Name = name;
-        }
-
-        public string Name { get; set; }
-    }
-
-    [LoggingAspect(Exclude = ExclusionFlags.Properties | ExclusionFlags.Constructors)]
-    public class PersonExcludePropertyConstructors
-    {
-        static PersonExcludePropertyConstructors()
-        {
-
-        }
-
-        public PersonExcludePropertyConstructors()
-        {
-        }
-
-        public PersonExcludePropertyConstructors(string name)
-        {
-            Name = name;
-        }
-
-        public string Name { get; set; }
     }
 }

--- a/PostSharpTutorial/LoggerAspect/LoggingAspect.cs
+++ b/PostSharpTutorial/LoggerAspect/LoggingAspect.cs
@@ -26,18 +26,6 @@ namespace LoggerAspect
 
         // The method name provided at compile time
         private string _methodName;
-        [NonSerialized]
-        private Action<string> _entryLogger;
-        [NonSerialized]
-        private Action<string, Exception> _exceptionLogger;
-        [NonSerialized]
-        private Action<string> _exitLogger;
-        [NonSerialized]
-        private Action<string> _resumeLogger;
-        [NonSerialized]
-        private Action<string> _successLogger;
-        [NonSerialized]
-        private Action<string> _yieldLogger;
 
         /// <summary>
         /// Gets or sets the logger.
@@ -64,72 +52,6 @@ namespace LoggerAspect
         /// The exclude flags.
         /// </value>
         public ExclusionFlags Exclude { get; set; }
-
-        private Action<string> EntryLogger
-        {
-            get
-            {
-                if (_entryLogger == null)
-                    _entryLogger = Logger.Debug;
-                return _entryLogger;
-            }
-            set { _entryLogger = value; }
-        }
-
-        private Action<string, Exception> ExceptionLogger
-        {
-            get
-            {
-                if (_exceptionLogger == null)
-                    _exceptionLogger = Logger.Error;
-                return _exceptionLogger;
-            }
-            set { _exceptionLogger = value; }
-        }
-
-        private Action<string> ExitLogger
-        {
-            get
-            {
-                if (_exitLogger == null)
-                    _exitLogger = Logger.Debug;
-                return _exitLogger;
-            }
-            set { _exitLogger = value; }
-        }
-
-        private Action<string> ResumeLogger
-        {
-            get
-            {
-                if (_resumeLogger == null)
-                    _resumeLogger = Logger.Debug;
-                return _resumeLogger;
-            }
-            set { _resumeLogger = value; }
-        }
-
-        private Action<string> SuccessLogger
-        {
-            get
-            {
-                if (_successLogger == null)
-                    _successLogger = Logger.Debug;
-                return _successLogger;
-            }
-            set { _successLogger = value; }
-        }
-
-        private Action<string> YieldLogger
-        {
-            get
-            {
-                if (_yieldLogger == null)
-                    _yieldLogger = Logger.Debug;
-                return _yieldLogger;
-            }
-            set { _yieldLogger = value; }
-        }
 
         /// <summary>
         /// Method invoked at build time to initialize the instance fields of the current aspect. This method is invoked
@@ -177,7 +99,7 @@ namespace LoggerAspect
             var arguments = GetArguments(args);
             var message = string.Format("Entering method {0}.{1} with ({2})", _className, _methodName,
                 FormatAguments(arguments));
-            EntryLogger(message);
+            Logger.Debug(message);
         }
 
         /// <summary>
@@ -191,7 +113,7 @@ namespace LoggerAspect
             var arguments = GetArguments(args);
             args.FlowBehavior = FlowBehavior.RethrowException;
             var message = string.Format("An exception occured in method {0}.{1} with ({2})", _className, _methodName, FormatAguments(arguments));
-            ExceptionLogger(message, args.Exception);
+            Logger.Error(message, args.Exception);
         }
 
         /// <summary>
@@ -206,7 +128,7 @@ namespace LoggerAspect
             var arguments = GetArguments(args);
             var message = string.Format("Exiting method {0}.{1} with ({2})", _className, _methodName,
                 FormatAguments(arguments));
-            ExitLogger(message);
+            Logger.Debug(message);
         }
 
         /// <summary>
@@ -220,7 +142,7 @@ namespace LoggerAspect
             var arguments = GetArguments(args);
             var message = string.Format("Resuming method {0}.{1} with ({2})", _className, _methodName,
                 FormatAguments(arguments));
-            ResumeLogger(message);
+            Logger.Debug(message);
         }
 
         /// <summary>
@@ -236,7 +158,7 @@ namespace LoggerAspect
             var returnValue = FormatObject(args.ReturnValue);
             var message = string.Format("Successfully finished method {0}.{1} with ({2}) retuning {3}", _className, _methodName,
                 FormatAguments(arguments), returnValue.Equals("NULL") ? "VOID" : returnValue);
-            SuccessLogger(message);
+            Logger.Debug(message);
         }
 
         /// <summary>
@@ -251,146 +173,9 @@ namespace LoggerAspect
             var arguments = GetArguments(args);
             var message = string.Format("Yielding result from method {0}.{1} with ({2})", _className, _methodName,
                 FormatAguments(arguments));
-            YieldLogger(message);
+            Logger.Debug(message);
         }
 
-        /// <summary>
-        /// Sets the on entry log level.
-        /// </summary>
-        /// <param name="logLevel">The level.</param>
-        public void SetOnEntryLevel(LoggingLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LoggingLevel.Debug:
-                    EntryLogger = Logger.Debug;
-                    break;
-                case LoggingLevel.Info:
-                    EntryLogger = Logger.Info;
-                    break;
-                case LoggingLevel.Trace:
-                    EntryLogger = Logger.Trace;
-                    break;
-                case LoggingLevel.Warn:
-                    EntryLogger = Logger.Warn;
-                    break;
-
-            }
-
-        }
-
-        /// <summary>
-        /// Sets the on exception level.
-        /// </summary>
-        /// <param name="logLevel">The log level.</param>
-        public void SetOnExceptionLevel(LoggingLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LoggingLevel.Error:
-                    ExceptionLogger = Logger.Error;
-                    break;
-                case LoggingLevel.Fatal:
-                    ExceptionLogger = Logger.Fatal;
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Sets the on exit level.
-        /// </summary>
-        /// <param name="logLevel">The log level.</param>
-        public void SetOnExitLevel(LoggingLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LoggingLevel.Debug:
-                    ExitLogger = Logger.Debug;
-                    break;
-                case LoggingLevel.Info:
-                    ExitLogger = Logger.Info;
-                    break;
-                case LoggingLevel.Trace:
-                    ExitLogger = Logger.Trace;
-                    break;
-                case LoggingLevel.Warn:
-                    ExitLogger = Logger.Warn;
-                    break;
-
-            }
-        }
-
-        /// <summary>
-        /// Sets the on resume level.
-        /// </summary>
-        /// <param name="logLevel">The log level.</param>
-        public void SetOnResumeLevel(LoggingLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LoggingLevel.Debug:
-                    ResumeLogger = Logger.Debug;
-                    break;
-                case LoggingLevel.Info:
-                    ResumeLogger = Logger.Info;
-                    break;
-                case LoggingLevel.Trace:
-                    ResumeLogger = Logger.Trace;
-                    break;
-                case LoggingLevel.Warn:
-                    ResumeLogger = Logger.Warn;
-                    break;
-
-            }
-        }
-
-        /// <summary>
-        /// Sets the on success level.
-        /// </summary>
-        /// <param name="logLevel">The log level.</param>
-        public void SetOnSuccessLevel(LoggingLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LoggingLevel.Debug:
-                    SuccessLogger = Logger.Debug;
-                    break;
-                case LoggingLevel.Info:
-                    SuccessLogger = Logger.Info;
-                    break;
-                case LoggingLevel.Trace:
-                    SuccessLogger = Logger.Trace;
-                    break;
-                case LoggingLevel.Warn:
-                    SuccessLogger = Logger.Warn;
-                    break;
-
-            }
-        }
-
-        /// <summary>
-        /// Sets the on yield level.
-        /// </summary>
-        /// <param name="logLevel">The log level.</param>
-        public void SetOnYieldLevel(LoggingLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LoggingLevel.Debug:
-                    YieldLogger = Logger.Debug;
-                    break;
-                case LoggingLevel.Info:
-                    YieldLogger = Logger.Info;
-                    break;
-                case LoggingLevel.Trace:
-                    YieldLogger = Logger.Trace;
-                    break;
-                case LoggingLevel.Warn:
-                    YieldLogger = Logger.Warn;
-                    break;
-
-            }
-        }
 
         private static string FormatAguments(IDictionary<string, object> arguments)
         {


### PR DESCRIPTION
Because the LoggerAspect cannot be accessed via instance, we cannot call an instance method on it to set the logging level, and when tried to do it via static method, it broke the other tests because the level will be compiled, so it cannot be changed during runtime, as such I recommend using the ILogger instance for different logging leves for explicit logging as seeing how in most cases the logging of methods in such detail has a high overhead, it should be at Debug level or lower and the Exception should be at error because at Fatal level the application should throw a meaningful exception when it breaks

Reordered the test project;
